### PR TITLE
fix: require patched Node.js versions for January 2026 security release

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 DO_NOT_TRACK=1
 
 [tools]
-nodejs = '24.5.0'
+nodejs = '24.13.0'
 pnpm = '10.26.0'
 gitleaks = '8.28.0'
 lefthook = '1.12.3'


### PR DESCRIPTION
## Summary

Updates `mise.toml` to Node 24.13.0 (from 24.5.0).

This version includes fixes for the [January 2026 Node.js security release](https://nodejs.org/en/blog/vulnerability/december-2025-security-releases) addressing 8 vulnerabilities (3 high, 4 medium, 1 low).