### PR TITLE
docs: update playground URL to api-v2.whisk.so

### DIFF
--- a/docs/steakhouse/pages/graphql.mdx
+++ b/docs/steakhouse/pages/graphql.mdx
@@ -4,7 +4,7 @@ Write your own GraphQL queries against the Whisk API with full type safety. Use 
 
 ## Playground
 
-The [Whisk GraphQL playground](https://api.whisk.so/graphql) is the best way to explore the schema and test queries before writing code.
+The [Whisk GraphQL playground](https://api-v2.whisk.so/graphql) is the best way to explore the schema and test queries before writing code.
 
 ::::steps
 ### Add your authorization header

--- a/docs/whisk/pages/getting-started.mdx
+++ b/docs/whisk/pages/getting-started.mdx
@@ -16,7 +16,7 @@ Don't see a kit you need? [Lets chat!](https://calendly.com/papercliplabs-spence
 
 ## Playground
 
-The [Whisk GraphQL playground](https://api.whisk.so/graphql) is the best way to explore the APIs comprehensive schema docs, and test queries:
+The [Whisk GraphQL playground](https://api-v2.whisk.so/graphql) is the best way to explore the APIs comprehensive schema docs, and test queries:
 
 ::::steps
 ### Get your test API key


### PR DESCRIPTION
## Summary
- Updates the GraphQL playground URL from `api.whisk.so` to `api-v2.whisk.so` in the getting started and direct GraphQL query docs

## Test plan
- [x] Verify playground links resolve correctly