### PR TITLE
fix: remove cacheExchange from WhiskClient

### DIFF
--- a/.changeset/remove-cache-exchange.md
+++ b/.changeset/remove-cache-exchange.md
@@ -1,0 +1,5 @@
+---
+"@whisk/client": patch
+---
+
+Remove urql's cacheExchange to prevent stale data on server-side singletons

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,8 +165,10 @@ export function useMyData(variables: GetMyDataVariables) {
 
 ## Releasing
 
+Always use `pnpm changeset` (interactive CLI) to create changesets — never create changeset files manually.
+
 ```bash
-pnpm changeset              # Create changeset describing your changes
+pnpm changeset              # Create changeset describing your changes (interactive)
 pnpm changeset:version      # Bump versions and update changelogs
 git add -A && git commit    # Commit the version bumps
 ```

--- a/packages/client/src/WhiskClient.ts
+++ b/packages/client/src/WhiskClient.ts
@@ -1,6 +1,5 @@
 import {
   type AnyVariables,
-  cacheExchange,
   fetchExchange,
   type TypedDocumentNode,
   Client as UrqlClient,
@@ -23,7 +22,7 @@ export class WhiskClient {
   constructor({ apiKey, url = DEFAULT_WHISK_API_URL, debug = false }: WhiskClientConfig) {
     this.urql = new UrqlClient({
       url,
-      exchanges: [scalarsExchange, cacheExchange, fetchExchange],
+      exchanges: [scalarsExchange, fetchExchange],
       fetchOptions: {
         headers: {
           Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
## Summary
- Remove urql's `cacheExchange` from the WhiskClient exchanges array to prevent stale data on server-side singletons
- The document cache persists across requests for the lifetime of the process, returning stale balance data after on-chain transactions
- Only `scalarsExchange` and `fetchExchange` remain, ensuring every query hits the network