### PR TITLE
fix(steakhouse): correct usdc-ready protocol to morpho_v2

### DIFF
--- a/.changeset/quick-olives-eat.md
+++ b/.changeset/quick-olives-eat.md
@@ -1,0 +1,5 @@
+---
+"@whisk/steakhouse": patch
+---
+
+Fix USDC Ready vault protocol (morpho_v1 → morpho_v2) and strengthen onchain verification to assert each vault's declared protocol matches the factory it was deployed from.

--- a/packages/steakhouse/src/metadata/generated/VAULTS.md
+++ b/packages/steakhouse/src/metadata/generated/VAULTS.md
@@ -28,7 +28,7 @@
 | Ethereum | `0xbeEF346d7099865208Ff331e4f648f4154DDAa05` | - | morpho_v1 | High Yield | ✗ |
 | Ethereum | `0x6D4e530B8431a52FFDA4516BA4Aadc0951897F8C` | - | morpho_v1 | Prime | ✗ |
 | Ethereum | `0xbEeFCe6c76C7D7A8066562Fe9FF0e343a52dD92F` | - | morpho_v1 | Prime | ✗ |
-| Ethereum | `0xbeeFf0956ACb02E6F203e83D6eaE357A1d7d116C` | - | morpho_v1 | High Yield | ✗ |
+| Ethereum | `0xbeeFf0956ACb02E6F203e83D6eaE357A1d7d116C` | - | morpho_v2 | High Yield | ✗ |
 | Ethereum | `0xBEefb9f61CC44895d8AEc381373555a64191A9c4` | - | morpho_v1 | Prime | ✗ |
 | Ethereum | `0xA1b60d96e5C50dA627095B9381dc5a46AF1a9a42` | - | morpho_v1 | Prime | ✗ |
 | Ethereum | `0x30881Baa943777f92DC934d53D3bFdF33382cab3` | - | morpho_v1 | Prime | ✗ |

--- a/packages/steakhouse/src/metadata/generated/vaults.ts
+++ b/packages/steakhouse/src/metadata/generated/vaults.ts
@@ -599,7 +599,7 @@ export const STEAKHOUSE_VAULTS: readonly VaultConfig[] = [
   {
     chainId: 1,
     address: "0xbeeFf0956ACb02E6F203e83D6eaE357A1d7d116C",
-    protocol: "morpho_v1",
+    protocol: "morpho_v2",
     strategy: "High Yield",
     isListed: false,
   },

--- a/packages/steakhouse/src/metadata/vault-verification.test.ts
+++ b/packages/steakhouse/src/metadata/vault-verification.test.ts
@@ -185,71 +185,79 @@ describe("Vault Deployment Verification", () => {
       }, 60000)
 
       if (hasFactory) {
-        it(`all ${vaults.length} vaults are from Morpho factory`, async () => {
+        it(`all ${vaults.length} vaults match their declared protocol factory`, async () => {
           const factoryCheckResults = await Promise.all(
             vaults.map(async (vault) => {
               const vaultAddress = vault.address as Address
-              let isFromFactory = false
 
-              // Check MetaMorpho v1.0 factory
-              if (factories.metaMorphoV1_0Factory) {
-                const isV1_0 = await client
-                  .readContract({
-                    address: factories.metaMorphoV1_0Factory,
-                    abi: metaMorphoFactoryAbi,
-                    functionName: "isMetaMorpho",
-                    args: [vaultAddress],
-                  })
-                  .catch(() => false)
-                if (isV1_0) isFromFactory = true
-              }
+              const [isV1_0, isV1_1, isV2] = await Promise.all([
+                factories.metaMorphoV1_0Factory
+                  ? client
+                      .readContract({
+                        address: factories.metaMorphoV1_0Factory,
+                        abi: metaMorphoFactoryAbi,
+                        functionName: "isMetaMorpho",
+                        args: [vaultAddress],
+                      })
+                      .catch(() => false)
+                  : Promise.resolve(false),
+                factories.metaMorphoV1_1Factory
+                  ? client
+                      .readContract({
+                        address: factories.metaMorphoV1_1Factory,
+                        abi: metaMorphoFactoryAbi,
+                        functionName: "isMetaMorpho",
+                        args: [vaultAddress],
+                      })
+                      .catch(() => false)
+                  : Promise.resolve(false),
+                factories.vaultV2Factory
+                  ? client
+                      .readContract({
+                        address: factories.vaultV2Factory,
+                        abi: vaultV2FactoryAbi,
+                        functionName: "isVaultV2",
+                        args: [vaultAddress],
+                      })
+                      .catch(() => false)
+                  : Promise.resolve(false),
+              ])
 
-              // Check MetaMorpho v1.1 factory
-              if (!isFromFactory && factories.metaMorphoV1_1Factory) {
-                const isV1_1 = await client
-                  .readContract({
-                    address: factories.metaMorphoV1_1Factory,
-                    abi: metaMorphoFactoryAbi,
-                    functionName: "isMetaMorpho",
-                    args: [vaultAddress],
-                  })
-                  .catch(() => false)
-                if (isV1_1) isFromFactory = true
-              }
+              const actualProtocol: "morpho_v1" | "morpho_v2" | null =
+                isV1_0 || isV1_1 ? "morpho_v1" : isV2 ? "morpho_v2" : null
 
-              // Check VaultV2 factory
-              if (!isFromFactory && factories.vaultV2Factory) {
-                const isV2 = await client
-                  .readContract({
-                    address: factories.vaultV2Factory,
-                    abi: vaultV2FactoryAbi,
-                    functionName: "isVaultV2",
-                    args: [vaultAddress],
-                  })
-                  .catch(() => false)
-                if (isV2) isFromFactory = true
-              }
-
-              return { vault, isFromFactory }
+              return { vault, actualProtocol }
             }),
           )
 
-          const failures: { address: string }[] = []
-          for (const { vault, isFromFactory } of factoryCheckResults) {
-            if (!isFromFactory) {
-              failures.push({ address: vault.address })
+          const failures: { address: string; declared: string; actual: string }[] = []
+          for (const { vault, actualProtocol } of factoryCheckResults) {
+            if (actualProtocol === null) {
+              failures.push({
+                address: vault.address,
+                declared: vault.protocol,
+                actual: "not from any Morpho factory",
+              })
+            } else if (actualProtocol !== vault.protocol) {
+              failures.push({
+                address: vault.address,
+                declared: vault.protocol,
+                actual: actualProtocol,
+              })
             }
           }
 
           if (failures.length > 0) {
-            console.log(`\n[Chain ${chainId}] Vaults NOT from Morpho factory:`)
+            console.log(`\n[Chain ${chainId}] Vaults with protocol/factory mismatch:`)
             console.log(`  v1.0: ${factories.metaMorphoV1_0Factory ?? "none"}`)
             console.log(`  v1.1: ${factories.metaMorphoV1_1Factory ?? "none"}`)
             console.log(`  v2: ${factories.vaultV2Factory ?? "none"}`)
             console.table(failures)
           }
 
-          expect(failures.length, `${failures.length} vaults not from factory`).toBe(0)
+          expect(failures.length, `${failures.length} vaults with protocol/factory mismatch`).toBe(
+            0,
+          )
         }, 60000)
       } else {
         it.skip(`No Morpho factory configured for chain ${chainId}`, () => {})

--- a/packages/steakhouse/src/metadata/vaults/mainnet/usdc-ready.md
+++ b/packages/steakhouse/src/metadata/vaults/mainnet/usdc-ready.md
@@ -1,7 +1,7 @@
 ---
 chainId: 1
 vaultAddress: "0xbeeFf0956ACb02E6F203e83D6eaE357A1d7d116C"
-protocol: morpho_v1
+protocol: morpho_v2
 strategy: High Yield
 isListed: false
 ---


### PR DESCRIPTION
## Summary
- The previously merged usdc-ready mainnet vault was configured as `morpho_v1` but is actually a Morpho V2 vault; switch it to `morpho_v2` and regenerate the vault registry.
- Tighten `vault-verification.test.ts` to assert each vault's declared `protocol` matches the factory it was actually deployed from (v1.0/v1.1 → `morpho_v1`, v2 → `morpho_v2`). Confirmed the check fails with the pre-fix config and points at the exact mismatched vault.