### PR TITLE
ci: use GitHub App token for release PRs

### DIFF
--- a/.changeset/plucky-goats-smile.md
+++ b/.changeset/plucky-goats-smile.md
@@ -1,0 +1,5 @@
+---
+"@whisk/client": patch
+---
+
+Add brief JSDoc on WhiskClient class.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,8 @@ jobs:
     needs: verify
     environment: release
     permissions:
-      contents: write
+      contents: read
       id-token: write
-      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -34,6 +33,10 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Clone repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
   changesets:
     name: Changesets
     needs: verify
+    environment: release
     permissions:
       contents: write
       id-token: write
@@ -27,13 +28,22 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Clone repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: PR or publish
         id: changesets
@@ -44,4 +54,4 @@ jobs:
           publish: pnpm run changeset:publish
           version: pnpm run changeset:version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,12 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PR or publish
         id: changesets
@@ -51,6 +52,7 @@ jobs:
         with:
           title: "chore: version packages"
           commit: "chore: version packages"
+          commitMode: "github-api"
           publish: pnpm run changeset:publish
           version: pnpm run changeset:version
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -55,7 +54,6 @@ jobs:
         with:
           title: "chore: version packages"
           commit: "chore: version packages"
-          commitMode: "github-api"
           publish: pnpm run changeset:publish
           version: pnpm run changeset:version
         env:

--- a/packages/client/src/WhiskClient.ts
+++ b/packages/client/src/WhiskClient.ts
@@ -15,6 +15,7 @@ export interface WhiskClientConfig {
   readonly debug?: boolean
 }
 
+/** GraphQL client for the Whisk API. */
 export class WhiskClient {
   private readonly urql: UrqlClient
   private readonly debug: boolean


### PR DESCRIPTION
## Summary
- Swap \`GITHUB_TOKEN\` for a short-lived installation token minted via \`actions/create-github-app-token\` in the \`changesets\` job.
- PRs opened/pushed by \`GITHUB_TOKEN\` do not trigger workflow runs (GitHub's recursion guard), which is why PR #103 is stuck with required checks never reporting. Using an App-minted token lets Verify run on auto-generated release PRs.
- \`RELEASE_APP_ID\` / \`RELEASE_APP_PRIVATE_KEY\` are read from a new \`release\` GitHub environment.

## Before merge
- [x] Confirm the \`release\` environment exists with secrets \`RELEASE_APP_ID\` and \`RELEASE_APP_PRIVATE_KEY\` set
- [x] Confirm the \`whisk-sdk-releases\` GitHub App is installed on this repo with the required permissions (contents: RW, pull-requests: RW)
- [x] After merge, close+reopen PR #103 (or push an empty commit to its branch) to re-trigger CI with the new token setup